### PR TITLE
Fix color adjustment utility

### DIFF
--- a/utils/lightenColor.js
+++ b/utils/lightenColor.js
@@ -1,11 +1,14 @@
 export default (col, amt) => {
-  col = parseInt(col.substring(1), 16);
-  return (
-    '#' +
-    (
-      ((col & 0x0000ff) + amt) |
-      ((((col >> 8) & 0x00ff) + amt) << 8) |
-      (((col >> 16) + amt) << 16)
-    ).toString(16)
-  );
+  let num = parseInt(col.slice(1), 16);
+
+  let r = (num >> 16) + amt;
+  let g = ((num >> 8) & 0xff) + amt;
+  let b = (num & 0xff) + amt;
+
+  r = Math.max(0, Math.min(255, r));
+  g = Math.max(0, Math.min(255, g));
+  b = Math.max(0, Math.min(255, b));
+
+  const out = (r << 16) | (g << 8) | b;
+  return `#${out.toString(16).padStart(6, '0')}`;
 };


### PR DESCRIPTION
## Summary
- ensure hex color lightening uses clamped RGB values

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_687d715e5b588322bc49212aeb7efaeb